### PR TITLE
fixed tests. Removed *. from certificate file reference

### DIFF
--- a/festivalspki_test.go
+++ b/festivalspki_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestLoadServerCertificateHandler(t *testing.T) {
 
-	handler := festivalspki.LoadServerCertificateHandler("certificates/*.festivalsapp.dev.crt", "certificates/*.festivalsapp.dev.key", "certificates/festivalsapp-development-root-ca.crt")
+	handler := festivalspki.LoadServerCertificateHandler("certificates/festivalsapp.dev.crt", "certificates/festivalsapp.dev.key", "certificates/festivalsapp-development-root-ca.crt")
 	_, err := handler(&tls.ClientHelloInfo{})
 	if err != nil {
 		t.Errorf("Handler failed to load server certificates.")
@@ -17,7 +17,7 @@ func TestLoadServerCertificateHandler(t *testing.T) {
 }
 
 func TestLoadServerCertificates(t *testing.T) {
-	_, err := festivalspki.LoadServerCertificates("certificates/*.festivalsapp.dev.crt", "certificates/*.festivalsapp.dev.key", "certificates/festivalsapp-development-root-ca.crt")
+	_, err := festivalspki.LoadServerCertificates("certificates/festivalsapp.dev.crt", "certificates/festivalsapp.dev.key", "certificates/festivalsapp-development-root-ca.crt")
 	if err != nil {
 		t.Errorf("Failed to load server certificates.")
 	}


### PR DESCRIPTION
The test **festivalspki_test.go** failed because the certificate files were specified as` "certificates/*.festivalsapp.dev.crt"`. These files were not found. Changed the test to look for `"certificates/festivalsapp.dev.crt"` etc...

The test now passes. But if the tested functions are expected to take wildcards, then the code should change and the test remain as it is.

You decide.